### PR TITLE
Fixed proxy url in browsersync config for windows.

### DIFF
--- a/extensions/roc-plugin-browsersync/src/browsersync.js
+++ b/extensions/roc-plugin-browsersync/src/browsersync.js
@@ -9,7 +9,7 @@ export default ({ context: { config: { settings } } }) => {
         return (port, path) => () => {
             browserSync({
                 // This proxy will remove extra slashes from the path, important to note
-                proxy: `0.0.0.0:${port}${path}`,
+                proxy: `localhost:${port}${path}`,
                 snippetOptions: {
                     rule: {
                         match: /<\/body>/i,


### PR DESCRIPTION
Using 0.0.0.0 as localhost address does not work on windows. Tested on windows 8 and 10 with clean web-app-react. Would be nice to have this merged in, to make projects created with roc new x web-app-react work out of the box without having to change port to the base address with no browsersync.